### PR TITLE
Fix FF 35 switch-to-tab bug

### DIFF
--- a/firefox/chrome/content/instantfox.js
+++ b/firefox/chrome/content/instantfox.js
@@ -939,7 +939,7 @@ InstantFox.handleCommand_ = function(aTriggeringEvent) {
 
     let matchLastLocationChange = true;
     if (action) {
-	    if (action.params) {
+        if (action.params) {
             // FF 35+
             url = action.params.url;
         } else {

--- a/firefox/chrome/content/instantfox.js
+++ b/firefox/chrome/content/instantfox.js
@@ -939,7 +939,13 @@ InstantFox.handleCommand_ = function(aTriggeringEvent) {
 
     let matchLastLocationChange = true;
     if (action) {
-        url = action.param;
+	    if (action.params) {
+            // FF 35+
+            url = action.params.url;
+        } else {
+            // FF 34-
+            url = action.param;
+        }
         if (this.hasAttribute("actiontype")) {
             if (action.type == "switchtab") {
                 this.handleRevert();


### PR DESCRIPTION
Trying to use switch-to-tab in FF 35 results in no action. This pull request fixes the bug.

Details:

---

    NS_ERROR_MALFORMED_URI: Component returned failure code: 0x804b000a (NS_ERROR_MALFORMED_URI) [nsIIOService2.newURI] browser.js:16542

This was due to a change in FF35 (https://github.com/mozilla/gecko-dev/commit/b660c827ef578584a6d302e51dd37d3bc1e25502#diff-32ca2785c0a7d5a2a606a647e164bfe3L742), apparently related to the new search bar.

`_parseActionUrl` now returns an object with a `params` property instead of the `param` property InstantFox expects. The `params` property itself is a string containing a `url` property, which should be (in this case) functionally identical to the old `param` property.