### PR TITLE
fix standard search plugins suggesting 1-2 line when devel mode.

### DIFF
--- a/firefox/chrome/content/instantfoxModule.js
+++ b/firefox/chrome/content/instantfoxModule.js
@@ -1090,7 +1090,6 @@ combinedSearch.prototype = {
                     search: entry.url,
                     url: r
                 };
-                this.applyInstantUrl();
                 this.notifyListener();
             }.bind(this));
         }


### PR DESCRIPTION
It bug display "title=>url" as suggest word.
For instance "instantfox quick search=>https://www.google.co.jp/webhp?hl=ja"
If select line, copy url as suggest word.

![instantfox-devel-mode-bug](https://cloud.githubusercontent.com/assets/2913112/7333750/9a86138a-ebb5-11e4-97e2-c30ec4b9b697.png)
