### PR TITLE
Fix result rendering in FF41+

### DIFF
--- a/firefox/chrome/content/urlbar.xml
+++ b/firefox/chrome/content/urlbar.xml
@@ -72,8 +72,10 @@
           }
 
           // Sort the regions by start position then end position
-          regions = regions.sort(function(a, b) let (start = a[0] - b[0])
-            start == 0 ? a[1] - b[1] : start);
+          regions = regions.sort(function(a, b) {
+            let start = a[0] - b[0];
+            return start == 0 ? a[1] - b[1] : start;
+          });
 
           // Generate the boundary indices from each region
           let start = 0;
@@ -334,8 +336,10 @@
           }
 
           // Sort the regions by start position then end position
-          regions = regions.sort(function(a, b) let (start = a[0] - b[0])
-            start == 0 ? a[1] - b[1] : start);
+          regions = regions.sort(function(a, b) {
+            let start = a[0] - b[0];
+            return start == 0 ? a[1] - b[1] : start;
+          });
 
           // Generate the boundary indices from each region
           let start = 0;


### PR DESCRIPTION
This fixes issue #115.

Seems that FF41 removed [expression closures](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Expression_Closures), at least in this context.

Note that these are still used in other places, e.g. `instantfoxModule.js:980`. This might break in the future - it would be a good idea to convert them to arrow functions or traditional function expressions. Occurrences can be found with the regex `function\s*\([^)]*\)\s*[^\s{]` and the fix is easy - but that is beyond the scope of this PR.