### PR TITLE
Register zh-TW in manifest

### DIFF
--- a/firefox/chrome.manifest
+++ b/firefox/chrome.manifest
@@ -29,6 +29,7 @@ locale    instantfox ru       chrome/locale/ru/
 locale    instantfox sv-SE    chrome/locale/sv-SE/
 locale    instantfox tr       chrome/locale/tr/
 locale    instantfox zh-CN    chrome/locale/zh-CN/
+locale    instantfox zh-TW    chrome/locale/zh-TW/
 
 #FF4
 #component {c541b971-0729-4f5d-a5c4-1f4dadef365e} components/instantfox_search.js


### PR DESCRIPTION
In v3.0.4, zh-TW still using zh-CN locale
Register zh-TW in manifest fix the problem